### PR TITLE
fix: microcopy object validator

### DIFF
--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -44,8 +44,8 @@ export default {
       validator(value) {
         const keys = ['today', 'next', 'previous'];
 
-        // Make sure all three keys are there
-        if (JSON.stringify(Object.keys(value)) !== JSON.stringify(keys)) {
+        // Make sure all required keys are there
+        if (keys.find(k => value[k] === undefined)) {
           return false;
         }
 

--- a/datepicker/datepicker.js
+++ b/datepicker/datepicker.js
@@ -49,8 +49,8 @@ export default {
       validator(value) {
         const keys = ['today', 'next', 'previous', 'open', 'cancel'];
 
-        // Make sure all three keys are there
-        if (JSON.stringify(Object.keys(value)) !== JSON.stringify(keys)) {
+        // Make sure all required keys are there
+        if (keys.find(k => value[k] === undefined)) {
           return false;
         }
 


### PR DESCRIPTION
There are additional props for microcopy validator of calendar at runtime (open and cancel) and is failing. This PR changes validator with a faster one which supports this condition. Date picker's validator is also changed for code consistency.

(Test is failing because it exists with code 1)

`DCO 1.1 Signed-off-by: Pooya Parsa <pooya@pi0.ir>`