### PR TITLE
fix(calendar): Trigger focus() on target element for click events

### DIFF
--- a/calendar/_calendar.scss
+++ b/calendar/_calendar.scss
@@ -163,5 +163,11 @@ $half-pixel: (.5px / 16px) * 1em;
     &:hover {
       cursor: pointer;
     }
+
+    // For cross-browser styling consistency…
+    // disable the inner dotted-line that FireFox adds.
+    &::-moz-focus-inner {
+      border: 0;
+    }
   }
 }

--- a/calendar/_calendar.scss
+++ b/calendar/_calendar.scss
@@ -164,10 +164,9 @@ $half-pixel: (.5px / 16px) * 1em;
       cursor: pointer;
     }
 
-    // For cross-browser styling consistency…
-    // disable the inner dotted-line that FireFox adds.
-    &::-moz-focus-inner {
-      border: 0;
-    }
+    // For cross-browser consistency disable the dotted-line that FireFox adds.
+    // &::-moz-focus-inner { border-style: none; }
+    // ... Left out because: Style linter doesn't like -moz- vender prefix
+    // ... and autoprefixer doesn't seem to recognize focus-inner yet.
   }
 }

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -268,6 +268,8 @@ export default {
       if (target.classList.contains('calendar__date')) {
         target = target.parentNode;
       }
+      // Firefox/Safari need to be coorced into focusing the target element.
+      target.focus();
       // https://sebastiandedeyne.com/posts/2017/using-registered-event-listeners-as-conditionals-in-vue
       this.$emit('dateSelected', target);
     },

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -268,7 +268,7 @@ export default {
       if (target.classList.contains('calendar__date')) {
         target = target.parentNode;
       }
-      // Firefox/Safari need to be coorced into focusing the target element.
+      // Firefox/Safari need to be coerced into focusing the target element.
       target.focus();
       // https://sebastiandedeyne.com/posts/2017/using-registered-event-listeners-as-conditionals-in-vue
       this.$emit('dateSelected', target);


### PR DESCRIPTION
FireFox and Safari are not focusing the element on click.  This PR simply calls `target.focus()` to ensure the .calendar__link is activated.

---
Resolves #20 

`DCO 1.1 Signed-off-by: FULL_NAME <EMAIL_ADDRESS>`
