### PR TITLE
:bug: Fixes issue where calendar will submit a parent form.

### DIFF
--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -272,6 +272,8 @@ export default {
       target.focus();
       // https://sebastiandedeyne.com/posts/2017/using-registered-event-listeners-as-conditionals-in-vue
       this.$emit('dateSelected', target);
+
+      e.preventDefault();
     },
     isFocusable(current) {
       const { today } = this;


### PR DESCRIPTION
When using the calendar or datepicker component within a `<form>`, choosing a date will cause that form to `submit`.
This prevents that action from happening automatically.

DCO 1.1 Signed-off-by: Joshua Hansen <hansenlj@us.ibm.com>