### PR TITLE
:new: Adds the `dateSelected` event to datepicker

### DIFF
--- a/datepicker/datepicker.js
+++ b/datepicker/datepicker.js
@@ -104,6 +104,8 @@ export default {
 
       this.$el.querySelector('.datepicker__popup').setAttribute('data-state', 'closed');
       this.$el.querySelector('.datepicker__input').focus();
+
+      this.$emit('dateSelected', target);
     },
   },
   computed: {

--- a/docs/components.js
+++ b/docs/components.js
@@ -131,6 +131,11 @@ export default {
       },
     ],
     events: [
+      {
+        name: 'dateSelected',
+        args: 'target',
+        description: 'When a click event is fired on a date, this event will fire and pass the relevant target of the event',
+      },
     ],
   },
 };


### PR DESCRIPTION
This follows the same pattern established from calendar.

DCO 1.1 Signed-off-by: Joshua Hansen <hansenlj@us.ibm.com>