### PR TITLE
:new: datepicker now supports v-model

### DIFF
--- a/datepicker/datepicker.js
+++ b/datepicker/datepicker.js
@@ -62,6 +62,14 @@ export default {
         return true;
       },
     },
+    value: {
+      type: Object,
+      default() {
+        return {
+          date: null, // could be `new Date()`
+        };
+      },
+    },
   },
   methods: {
     t(value, props = {}) {
@@ -98,31 +106,44 @@ export default {
       this.$el.querySelector('.datepicker__popup').setAttribute('data-state', 'closed');
     },
     select(target) {
-      this.selectedDay = target.dataset.day;
-      this.selectedMonth = target.dataset.month;
-      this.selectedYear = target.dataset.year;
-
       this.$el.querySelector('.datepicker__popup').setAttribute('data-state', 'closed');
       this.$el.querySelector('.datepicker__input').focus();
 
+      this.value.date = new Date(`${target.dataset.year}-${target.dataset.month}-${target.dataset.day}`);
+
       this.$emit('dateSelected', target);
+      this.$emit('input', this.value);
     },
   },
   computed: {
     selectedLocal() {
-      const date = new Date(this.selectedYear, this.selectedMonth, this.selectedDay);
-      if (this.selectedYear === '' || this.selectedMonth === '' || this.selectedDay === '') {
+      if (this.value.date === null) {
         return '';
       }
 
-      return date.toLocaleDateString(this.locale);
+      return this.value.date.toLocaleDateString(this.locale);
+    },
+    selectedYear() {
+      if (this.value.date === null) {
+        return '';
+      }
+      return this.value.date.getFullYear();
+    },
+    selectedMonth() {
+      if (this.value.date === null) {
+        return '';
+      }
+      return this.value.date.getMonth();
+    },
+    selectedDay() {
+      if (this.value.date === null) {
+        return '';
+      }
+      return this.value.date.getDate();
     },
   },
   data() {
     return {
-      selectedDay: '',
-      selectedMonth: '',
-      selectedYear: '',
     };
   },
 };

--- a/datepicker/datepicker.js
+++ b/datepicker/datepicker.js
@@ -66,7 +66,9 @@ export default {
       type: Object,
       default() {
         return {
-          date: null, // could be `new Date()`
+          year: '',
+          month: '',
+          day: '',
         };
       },
     },
@@ -109,7 +111,9 @@ export default {
       this.$el.querySelector('.datepicker__popup').setAttribute('data-state', 'closed');
       this.$el.querySelector('.datepicker__input').focus();
 
-      this.value.date = new Date(`${target.dataset.year}-${target.dataset.month}-${target.dataset.day}`);
+      this.value.year = target.dataset.year;
+      this.value.month = target.dataset.month;
+      this.value.day = target.dataset.day;
 
       this.$emit('dateSelected', target);
       this.$emit('input', this.value);
@@ -117,29 +121,25 @@ export default {
   },
   computed: {
     selectedLocal() {
-      if (this.value.date === null) {
+      if (this.value.year === '' || this.value.month === '' || this.value.day === '') {
         return '';
       }
 
-      return this.value.date.toLocaleDateString(this.locale);
+      const date = new Date();
+      date.setFullYear(this.value.year);
+      date.setMonth(this.value.month);
+      date.setDate(this.value.day);
+
+      return date.toLocaleDateString(this.locale);
     },
     selectedYear() {
-      if (this.value.date === null) {
-        return '';
-      }
-      return this.value.date.getFullYear();
+      return this.value.year;
     },
     selectedMonth() {
-      if (this.value.date === null) {
-        return '';
-      }
-      return this.value.date.getMonth();
+      return this.value.month;
     },
     selectedDay() {
-      if (this.value.date === null) {
-        return '';
-      }
-      return this.value.date.getDate();
+      return this.value.day;
     },
   },
   data() {


### PR DESCRIPTION
Allows datepicker to use the `v-model` attribute.
It has to be an object with `date`

*Example:*

`<datepicker v-model="start"></datepicker>`

```
start: {
  date: new Date(),
}
```

`date` can be null
datepicker works just fine without `v-model`

---
Resolves #26 

`DCO 1.1 Signed-off-by: Joshua hansen <hansenlj@us.ibm.com>`
