### PR TITLE
Fix test errors and warnings

### DIFF
--- a/calendar/calendar.html
+++ b/calendar/calendar.html
@@ -9,7 +9,7 @@
       </tr>
     </thead>
     <tbody class="calendar__body" @keydown.left="calendarNav('prev', $event)" @keydown.right="calendarNav('next', $event)" @keydown.up="calendarNav('up', $event)" @keydown.down="calendarNav('down', $event)">
-      <tr class="calendar__week" v-for="week in calendar.days" @click="select" :key="'week--' + week">
+      <tr class="calendar__week" v-for="(week, index) in calendar.days" @click="select" :key="'week--' + week + index">
         <td :class="day.status ? `calendar__day--${day.status}` : 'calendar__day'" v-for="day in week" :key="day.string">
           <!-- Make only "active" or "1" focusable -->
           <button :tabindex="day.focusable ? 0 : -1" class="calendar__link" :data-day="day.day" :data-month="day.month" :data-year="day.year" :ref="'calendar'" :aria-label="day.string"><span class="calendar__date">{{ day.dayString }}</span></button>

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -361,7 +361,9 @@ export default {
       return current.day === this.today.day && current.month === this.today.month && current.year === this.today.year;
     },
     navigate(dir, e) {
-      e.preventDefault();
+      if (e) {
+        e.preventDefault();
+      }
 
       const move = {};
       if (dir === 'next') {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/IBM/vue-a11y-calendar#readme",
   "devDependencies": {
     "@nuxtjs/markdownit": "^1.1.2",
-    "@nuxtjs/pwa": "^0.2.1",
+    "@nuxtjs/pwa": "^2.6.0",
     "ava": "^0.22.0",
     "babel-eslint": "^8.0.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
I was unable to run the tests:
- `methods.navigate` failed due to the method requiring a DOM event as a second parameter
- Many tests showed the `duplicate key` warning warning which is [also visible in the browser console](https://github.com/IBM/vue-a11y-calendar/issues/31)
- Nuxt failed with `TypeError: Cannot read property 'emit' of undefined` due to `@nuxtjs/pwa@0.2.1` not locking down dependencies and accidentally requiring some non-compatible `@nuxtjs@3.0.0-beta` packages

---
Resolves #31

`DCO 1.1 Signed-off-by: Thomas Jaggi <thomas@responsive.ch>`
