### PR TITLE
Highlight selected date

### DIFF
--- a/calendar/_calendar.scss
+++ b/calendar/_calendar.scss
@@ -150,6 +150,11 @@ $outline-color: #757575 !default;
       background: mix($white, $yellow, 50%);
       border: $half-pixel solid $black;
     }
+
+    &--selected {
+      background: mix($white, $red, 50%);
+      border: $half-pixel solid $black;
+    }
   }
 
   &__link {

--- a/calendar/calendar.html
+++ b/calendar/calendar.html
@@ -9,7 +9,7 @@
       </tr>
     </thead>
     <tbody class="calendar__body" @keydown.left="calendarNav('prev', $event)" @keydown.right="calendarNav('next', $event)" @keydown.up="calendarNav('up', $event)" @keydown.down="calendarNav('down', $event)">
-      <tr class="calendar__week" v-for="week in calendar.days" @click="select" :key="'week--' + week">
+      <tr class="calendar__week" v-for="(week, index) in calendar.days" @click="select" :key="'week--' + week + index">
         <td :class="day.status ? `calendar__day--${day.status}` : 'calendar__day'" v-for="day in week" :key="day.string">
           <!-- Make only "active" or "1" focusable -->
           <button :tabindex="day.focusable ? 0 : -1" class="calendar__link" :data-day="day.day" :data-month="day.month" :data-year="day.year" :ref="'calendar'" :aria-label="day.string"><span class="calendar__date">{{ day.dayString }}</span></button>

--- a/calendar/calendar.html
+++ b/calendar/calendar.html
@@ -10,9 +10,9 @@
     </thead>
     <tbody class="calendar__body" @keydown.left="calendarNav('prev', $event)" @keydown.right="calendarNav('next', $event)" @keydown.up="calendarNav('up', $event)" @keydown.down="calendarNav('down', $event)">
       <tr class="calendar__week" v-for="(week, index) in calendar.days" @click="select" :key="'week--' + week + index">
-        <td :class="day.status ? `calendar__day--${day.status}` : 'calendar__day'" v-for="day in week" :key="day.string">
+        <td :class="{ 'calendar__day': true, [`calendar__day--${day.status}`]: day.status, 'calendar__day--selected': isSelected(day) }" v-for="day in week" :key="day.string">
           <!-- Make only "active" or "1" focusable -->
-          <button :tabindex="day.focusable ? 0 : -1" class="calendar__link" :data-day="day.day" :data-month="day.month" :data-year="day.year" :ref="'calendar'" :aria-label="day.string"><span class="calendar__date">{{ day.dayString }}</span></button>
+          <button :tabindex="day.focusable ? 0 : -1" class="calendar__link" :data-day="day.day" :data-month="day.month" :data-year="day.year" :ref="'calendar'" :aria-label="day.string" :aria-selected="isSelected(day)"><span class="calendar__date">{{ day.dayString }}</span></button>
         </td>
       </tr>
     </tbody>

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -361,7 +361,9 @@ export default {
       return current.day === this.today.day && current.month === this.today.month && current.year === this.today.year;
     },
     navigate(dir, e) {
-      e.preventDefault();
+      if (e) {
+        e.preventDefault();
+      }
 
       const move = {};
       if (dir === 'next') {

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -57,6 +57,16 @@ export default {
         return true;
       },
     },
+    selectedDate: {
+      type: Object,
+      default() {
+        return {
+          day: '',
+          month: '',
+          year: '',
+        };
+      },
+    },
   },
   computed: {
     months() {
@@ -359,6 +369,12 @@ export default {
     },
     isToday(current) {
       return current.day === this.today.day && current.month === this.today.month && current.year === this.today.year;
+    },
+    isSelected(date) {
+      const { day, month, year } = this.selectedDate;
+      const isSelected = date.day === parseInt(day, 10) && date.month === parseInt(month, 10) && date.year === parseInt(year, 10);
+
+      return isSelected;
     },
     navigate(dir, e) {
       if (e) {

--- a/datepicker/datepicker.html
+++ b/datepicker/datepicker.html
@@ -18,7 +18,7 @@
   </div>
 
   <div class="datepicker__popup" aria-label="Date Picker" role="application" @keydown.tab="tabcapture" @keydown.esc="cancel" tabindex="-1">
-    <calendar class="datepicker__calendar" @dateSelected="select" :locale="locale" :microcopy="microcopy"></calendar>
+    <calendar class="datepicker__calendar" @dateSelected="select" :locale="locale" :microcopy="microcopy" :selectedDate="value"></calendar>
     <button class="datepicker__cancel" @click="cancel">Cancel</button>
   </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/IBM/vue-a11y-calendar#readme",
   "devDependencies": {
     "@nuxtjs/markdownit": "^1.1.2",
-    "@nuxtjs/pwa": "^0.2.1",
+    "@nuxtjs/pwa": "^2.6.0",
     "ava": "^0.22.0",
     "babel-eslint": "^8.0.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
IMHO it would make sense for both visually impaired and non-impaired users to have the selected date highlighted (using aria-selected in the former case and a different color in the latter).

NOTE: This PR is based on https://github.com/IBM/vue-a11y-calendar/pull/32 since I was unable to run the project without these changes.

---
Resolves #33 

`DCO 1.1 Signed-off-by: Thomas Jaggi <thomas@responsive.ch>`
